### PR TITLE
Convert fixture to simple test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,5 @@ docs/_build/
 # Ignore mypy cache
 .mypy_cache
 
-# Autotest artifacts
-autotest/bin
-autotest/temp
+# Test artifacts
+tests/bin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 import pytest
-import pymake
 import platform
-import os
 from pathlib import Path
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,51 +6,11 @@ from pathlib import Path
 
 
 @pytest.fixture(scope="session")
-def get_shared_object(tmpdir_factory):
-
-    tmp_dir = tmpdir_factory.getbasetemp()
-    bin_dir = tmp_dir / "bin"
-    download_dir = tmp_dir / "download"
-
-    pymake.download_and_unzip(
-        url="https://github.com/MODFLOW-USGS/modflow6/archive/develop.zip",
-        pth=str(download_dir),
-    )
-
-    # set source and target paths
-    srcdir = download_dir / "modflow6-develop" / "srcbmi"
-    comdir = download_dir / "modflow6-develop" / "src"
-    excludefiles = [str(comdir / "mf6.f90")]
-    target = str(bin_dir / "libmf6")
-
-    # make sure the correct extension is used for each operating system
-    eext = ".so"
+def get_shared_object_path():
     sysinfo = platform.system()
     if sysinfo.lower() == "windows":
-        eext = ".dll"
-    target += eext
+        lib_name = "libmf6.dll"
+    else:
+        lib_name = "libmf6.so"
+    return str(Path(__file__).parent / "bin" / lib_name)
 
-    fc, cc = pymake.set_compiler("mf6")
-
-    fflags = None
-    if fc == "gfortran":
-        # some flags to check for errors in the code
-        # add -Werror for compilation to terminate if errors are found
-        fflags = (
-            "-Wtabs -Wline-truncation -Wunused-label "
-            "-Wunused-variable -pedantic -std=f2008"
-        )
-
-    pymake.main(
-        str(srcdir),
-        target,
-        fc=fc,
-        cc=cc,
-        include_subdirs=True,
-        fflags=fflags,
-        srcdir2=str(comdir),
-        excludefiles=excludefiles,
-        sharedobject=True,
-    )
-
-    return target

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,8 +1,5 @@
 import os
 import pymake
-from pathlib import Path
-import platform
-import shutil
 
 
 def test_compile_shared_object(get_shared_object_path, tmp_path):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,6 +1,51 @@
 import os
+import pymake
+from pathlib import Path
+import platform
+import shutil
 
 
-def test_get_shared_object(get_shared_object):
-    lib_path = get_shared_object
-    assert os.path.isfile(lib_path), f"{lib_path} does not exist"
+def test_compile_shared_object(get_shared_object_path, tmp_path):
+    """Test which compiles the shared object.
+
+    Needs to be run before other tests are run.
+    Might be replaced by a fixture as soon as Modflow provides nightly shared libs.
+    """
+
+    target = get_shared_object_path
+    download_dir = tmp_path / "download"
+
+    pymake.download_and_unzip(
+        url="https://github.com/MODFLOW-USGS/modflow6/archive/develop.zip",
+        pth=str(download_dir),
+    )
+
+    # set source and target paths
+    srcdir = download_dir / "modflow6-develop" / "srcbmi"
+    comdir = download_dir / "modflow6-develop" / "src"
+    excludefiles = [str(comdir / "mf6.f90")]
+
+    fc, cc = pymake.set_compiler("mf6")
+
+    fflags = None
+    if fc == "gfortran":
+        # some flags to check for errors in the code
+        # add -Werror for compilation to terminate if errors are found
+        fflags = (
+            "-Wtabs -Wline-truncation -Wunused-label "
+            "-Wunused-variable -pedantic -std=f2008"
+        )
+
+    pymake.main(
+        str(srcdir),
+        target,
+        fc=fc,
+        cc=cc,
+        include_subdirs=True,
+        fflags=fflags,
+        srcdir2=str(comdir),
+        excludefiles=excludefiles,
+        sharedobject=True,
+    )
+
+    assert os.path.isfile(target), f"{target} does not exist"


### PR DESCRIPTION
Until modflow provides nightly builds this is the only feasible (but unfortunately less robust) way to do it.

Note:
The unified view seems to be broken for this commit.
Split view works.
