### PR TITLE
First unit tests

### DIFF
--- a/amipy/amiwrapper.py
+++ b/amipy/amiwrapper.py
@@ -8,8 +8,10 @@ from ctypes import (
     c_void_p,
     cdll,
     create_string_buffer,
+    CDLL,
 )
 from typing import Tuple
+import sys
 
 import numpy as np
 from amipy.ami import Ami
@@ -26,9 +28,17 @@ class AmiWrapper(Ami):
     """
 
     def __init__(self, lib_path: str, lib_dependencies: Iterable[str] = None):
-        if hasattr(os, "add_dll_directory"):
-            os.add_dll_directory(os.path.dirname(lib_path))
-        self.lib = cdll.LoadLibrary(lib_path)
+
+        if sys.version_info[0:2] < (3, 8):
+            # Python version < 3.8
+            self.lib = CDLL(lib_path)
+        else:
+            # LoadLibraryEx flag: LOAD_WITH_ALTERED_SEARCH_PATH 0x08
+            # -> uses the altered search path for resolving ddl dependencies
+            # Note: this could make amipy less secure (dll-injection)
+            # Can we get it to work without this flag?
+            self.lib = CDLL(lib_path, winmode=0x08)
+
         self.MAXSTRLEN = self.get_constant_int("MAXSTRLEN")
         self.working_directory = "."
         self.previous_directory = "."

--- a/amipy/amiwrapper.py
+++ b/amipy/amiwrapper.py
@@ -26,12 +26,12 @@ class AmiWrapper(Ami):
     """
 
     def __init__(self, lib_path: str, lib_dependencies: Iterable[str] = None):
+        if hasattr(os, "add_dll_directory"):
+            os.add_dll_directory(os.path.dirname(lib_path))
         self.lib = cdll.LoadLibrary(lib_path)
         self.MAXSTRLEN = self.get_constant_int("MAXSTRLEN")
         self.working_directory = "."
         self.previous_directory = "."
-        if hasattr(os, "add_dll_directory"):
-            os.add_dll_directory(os.path.dirname(lib_path))
 
         self._add_lib_dependencies(lib_dependencies)
 

--- a/amipy/amiwrapper.py
+++ b/amipy/amiwrapper.py
@@ -30,6 +30,8 @@ class AmiWrapper(Ami):
         self.MAXSTRLEN = self.get_constant_int("MAXSTRLEN")
         self.working_directory = "."
         self.previous_directory = "."
+        if hasattr(os, "add_dll_directory"):
+            os.add_dll_directory(os.path.dirname(lib_path))
 
         self._add_lib_dependencies(lib_dependencies)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
 import pytest
 import platform
 from pathlib import Path
+import flopy
 
 
 @pytest.fixture(scope="session")
-def get_shared_object_path():
+def modflow_lib_path():
     sysinfo = platform.system()
     if sysinfo.lower() == "windows":
         lib_name = "libmf6.dll"
@@ -12,3 +13,29 @@ def get_shared_object_path():
         lib_name = "libmf6.so"
     return str(Path(__file__).parent / "bin" / lib_name)
 
+
+@pytest.fixture(scope="function")
+def flopy_dis(tmp_path_factory):
+    name = "test_model_dis"
+    tmp_dir = tmp_path_factory.mktemp(name)
+    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=str(tmp_dir))
+    flopy.mf6.ModflowTdis(sim)
+    flopy.mf6.ModflowIms(sim)
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)
+    flopy.mf6.ModflowGwfdis(gwf, nrow=10, ncol=10)
+    flopy.mf6.ModflowGwfic(gwf)
+    flopy.mf6.ModflowGwfnpf(gwf, save_specific_discharge=True)
+    flopy.mf6.ModflowGwfchd(
+        gwf, stress_period_data=[[(0, 0, 0), 1.0], [(0, 9, 9), 0.0]]
+    )
+    budget_file = name + ".bud"
+    head_file = name + ".hds"
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord=budget_file,
+        head_filerecord=head_file,
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+    sim.write_simulation()
+    model_dir = str(tmp_dir)
+    return (model_dir, sim)

--- a/tests/test_000_setup.py
+++ b/tests/test_000_setup.py
@@ -2,14 +2,14 @@ import os
 import pymake
 
 
-def test_compile_shared_object(get_shared_object_path, tmp_path):
+def test_compile_modflow_lib(modflow_lib_path, tmp_path):
     """Test which compiles the shared object.
 
     Needs to be run before other tests are run.
     Might be replaced by a fixture as soon as Modflow provides nightly shared libs.
     """
 
-    target = get_shared_object_path
+    target = modflow_lib_path
     download_dir = tmp_path / "download"
 
     pymake.download_and_unzip(

--- a/tests/test_unit_modflow_dis.py
+++ b/tests/test_unit_modflow_dis.py
@@ -1,0 +1,15 @@
+import os
+from amipy import AmiWrapper
+
+
+def test_initialize_dis(flopy_dis, modflow_lib_path):
+    model_path, sim = flopy_dis
+    os.chdir(model_path)
+    mf6 = AmiWrapper(modflow_lib_path)
+
+    # write output to screen:
+    mf6.set_int("ISTDOUTTOFILE", 0)
+
+    # run initialize
+    mf6_config_file = os.path.join(model_path, "mfsim.nam")
+    mf6.initialize(mf6_config_file)


### PR DESCRIPTION
For Python >=3.8 uses
LoadLibraryEx flag: LOAD_WITH_ALTERED_SEARCH_PATH 0x08
It will then use the altered search path for resolving ddl dependencies
Note: this could make amipy less secure (dll-injection)
Can we get it to work without this flag?