### PR TITLE
Change to developer mode

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
           gfortran --version
       - name: Install amipy
         run: |
-          pip install .
+          pip install -e .
       - name: Install test dependencies
         run: |
           pip install -r test_dependencies.txt


### PR DESCRIPTION
Summary: code coverage reports only work when you install your package with:
```
pip install -e .
```